### PR TITLE
fix: make default keymaps unmappable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ vim.opt.sessionoptions = {
   -- reattached to every buffer on enter, to avoid
   -- lazy loaded packages from stealing them.
   --
-  -- Set this to nil if you wish to set keymaps by yourself.
+  -- Set this to false if you wish to set keymaps by yourself.
   keymaps = {
     bracket_movement_key = "b", -- Like [b, ]b, [B, ]B
     buffer_close_key = "k", -- Like <leader>bk

--- a/lua/windovigation/init.lua
+++ b/lua/windovigation/init.lua
@@ -114,7 +114,7 @@ local function is_options_valid(user_options)
     keymaps = {
       user_options.keymaps,
       function(value)
-        if value == nil then
+        if value == false then
           return true
         end
 

--- a/lua/windovigation/keymaps.lua
+++ b/lua/windovigation/keymaps.lua
@@ -5,7 +5,7 @@ local M = {}
 
 ---@param buf integer?
 M.set_default_keymaps = function(buf)
-  if options.keymaps == nil then
+  if not options.keymaps then
     return
   end
 


### PR DESCRIPTION
The current instruction in the README regarding opting out of default mappings is misleading, since in lua, as far as I know, nil field = non-defined field.

Because of this plugins usually require users to opt out of mappings by booleans. For example:

```lua
		require("oil").setup({
			keymaps = {
				["m"] = "actions.close",
				["="] = "actions.parent",
				[";"] = "actions.refresh",
				["<C-w>"] = "actions.select_vsplit",
				["~"] = false,
				["-"] = false,
				["_"] = false,
				["`"] = false,
				["<C-h>"] = false,
				["<C-s>"] = false,
				["<C-t>"] = false,
			},
		})
```

This PR provides a simple fix for that.